### PR TITLE
[HOPSWORKS-1232] Add a thrift as required extras

### DIFF
--- a/pyhive/__init__.py
+++ b/pyhive/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-__version__ = '0.6.3'
+__version__ = '0.6.4'

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'presto': ['requests>=1.0.0'],
         'hive': ['sasl>=0.2.1', 'thrift>=0.10.0', 'thrift_sasl>=0.1.0'],
         'sqlalchemy': ['sqlalchemy>=0.8.7'],
+        'thrift': ['thrift>=0.10.0'],
     },
     tests_require=[
         'mock>=1.0.0',


### PR DESCRIPTION
Add an option to add thrift only as required extras to be able to
install without sasl.